### PR TITLE
Add UPLOADCARE_STORE=auto to default settings?

### DIFF
--- a/lib/uploadcare.rb
+++ b/lib/uploadcare.rb
@@ -16,6 +16,7 @@ module Uploadcare
       static_url_base: 'http://www.ucarecdn.com',
       api_version: '0.3',
       cache_files: true,
+      store: 'auto',
     }
   end
 

--- a/lib/uploadcare/uploader.rb
+++ b/lib/uploadcare/uploader.rb
@@ -8,7 +8,7 @@ module Uploadcare
     end
 
     def upload_url(url, timeout=30, interval=0.3)
-      token = response :post, '/from_url/', { source_url: url, pub_key: @options[:public_key] }
+      token = response :post, '/from_url/', { source_url: url, pub_key: @options[:public_key], store: @options[:store] }
       Timeout.timeout(timeout) do
         sleep interval while (r = upload_url_status(token))['status'] != 'success'
         r.fetch('file_id')
@@ -19,6 +19,7 @@ module Uploadcare
 
       resp = response :post, '/base/', {
         UPLOADCARE_PUB_KEY: @options[:public_key],
+        UPLOADCARE_STORE: @options[:store],
         file: Faraday::UploadIO.new(path, MIME::Types.of(path)[0].content_type)
       }
       resp['file']


### PR DESCRIPTION
Hello,

Right now I can't see a way to pass the UPLOADCARE_STORE setting to `Uploader#upload_file` or `Uploader#upload_url`.

Would you accept a PR to add this parameter to the `Uploadcare.default_settings` method and have it default to `auto` and allow it to be overridden when constructing an API object?